### PR TITLE
Add link to Android Kotlin styling conventions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,7 +38,7 @@ HA_QUICKBARS_KEY_PASSWORD="dummy"
 In Android Studio, ensure you are using the debug build variant. This variant uses the standard Android debug key and ignores the production signing configuration.
 
 ## :art: Code Style
-To keep the codebase clean and readable, please ensure your code follows standard Android Kotlin styling conventions. Before submitting a PR, run the standard Android Studio auto-formatter (Ctrl+Alt+L on Windows, Cmd+Option+L on Mac) on any files you have modified.
+To keep the codebase clean and readable, please ensure your code follows standard [Android Kotlin styling conventions](https://developer.android.com/kotlin/style-guide). Before submitting a PR, run the standard Android Studio auto-formatter (Ctrl+Alt+L on Windows, Cmd+Option+L on Mac) on any files you have modified.
 
 ## :test_tube: Testing & Quality Assurance
 Because QuickBars interacts with system-level overlays and physical remote key interception, testing is currently a manual process.


### PR DESCRIPTION
## :memo: Description
Updated code style section to include a link to Android Kotlin styling conventions.

## :mag: Related Issue
No Issue on the subject.

## :bulb: Motivation and Context
Brain-dead proofing for easier contributions :D

## :tv: Screenshots / Video (if applicable)
not applicable

## :test_tube: How Has This Been Tested?
Manual QA (opening the link)

## :books: Documentation Updates
Does this PR introduce new features or change existing behavior that requires updates to the official user guide?
- [X] No documentation changes required.
- [ ] Yes, the documentation at [quickbars.app/guide](https://quickbars.app/guide) needs to be updated.
    - *If yes, briefly detail what needs changing in the docs here:* ## :white_check_mark: Checklist
- [X] My code follows the code style of this project.
- [X] I have performed a self-review of my own code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [X] My changes generate no new warnings or build errors.
