### PR TITLE
Add aggressive activity fallback for apps missing Leanback intent

### DIFF
--- a/app/src/main/java/dev/trooped/tvquickbars/utils/AppUtils.kt
+++ b/app/src/main/java/dev/trooped/tvquickbars/utils/AppUtils.kt
@@ -100,7 +100,36 @@ fun Context.getBestLaunchIntent(packageName: String): Intent? {
         }
     }
 
-    // 4. Special case: Amazon Prime Video
+    // 4. Aggressive fallback: scan all declared activities for a likely entry point
+    try {
+        val packageInfo = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            pm.getPackageInfo(packageName, PackageManager.PackageInfoFlags.of(PackageManager.GET_ACTIVITIES.toLong()))
+        } else {
+            @Suppress("DEPRECATION")
+            pm.getPackageInfo(packageName, PackageManager.GET_ACTIVITIES)
+        }
+
+        val activities = packageInfo.activities
+        if (activities != null && activities.isNotEmpty()) {
+            val entryPointKeywords = listOf("main", "splash", "tv", "leanback", "launcher", "home")
+
+            val exported = activities.filter { it.exported }
+            val candidates = exported.ifEmpty { activities.toList() }
+
+            val bestMatch = candidates.firstOrNull { activity ->
+                val name = activity.name.lowercase()
+                entryPointKeywords.any { keyword -> name.contains(keyword) }
+            } ?: candidates[0]
+
+            return Intent(Intent.ACTION_MAIN).apply {
+                component = ComponentName(packageName, bestMatch.name)
+            }
+        }
+    } catch (_: PackageManager.NameNotFoundException) {
+        // Package not installed, fall through
+    }
+
+    // 5. Special case: Amazon Prime Video
     if (packageName == "com.amazon.amazonvideo.livingroom") {
         val knownActivities = listOf(
             "com.amazon.ignition.IgnitionActivity",


### PR DESCRIPTION
## Summary
- Adds a new fallback step (step 4) in `getBestLaunchIntent()` that queries `PackageManager.GET_ACTIVITIES` to scan all declared activities when standard intent resolution fails
- Prioritizes exported activities with entry-point keywords (`main`, `splash`, `tv`, `leanback`, `launcher`, `home`) before falling back to the first available activity
- Handles API level differences for `getPackageInfo` (Tiramisu+ vs legacy)
- Existing resolution steps (1-3) and the Amazon Prime Video special case (now step 5) are completely untouched

## Testing notes
I don't have an Android TV device to verify the fix end-to-end with a problematic app like OdidoTv. Would appreciate if someone with access to a device and a known-failing app could validate.

Fixes #31